### PR TITLE
refactor: swap out old query param code for shiny new RegExp code

### DIFF
--- a/tests/customer_request_delete.test.js
+++ b/tests/customer_request_delete.test.js
@@ -56,8 +56,8 @@ describe("Customer_Delete", () => {
   });
 
   test("make().version() should replace query param when one is provided to constructor", () => {
-    let expected = "/ABC?version=19";
+    let expected = "/123?version=19";
     del.make().version(19);
-    expect(del.endpoint).toEqual(endpoint);
+    expect(del.endpoint).toEqual(expected);
   });
 });


### PR DESCRIPTION
Swap out old query param code for new RegExp code